### PR TITLE
feat: /effectsの導入と外部エフェクト呼び出し

### DIFF
--- a/effects/TestEffect.js
+++ b/effects/TestEffect.js
@@ -1,0 +1,17 @@
+export function drawTestEffect(s, { sec }) {
+  s.push();
+  s.noStroke();
+
+  const n = 12;
+  const w = s.width / n;
+
+  for (let i = 0; i < n; i++) {
+    const phase = sec * 1.2 + i * 0.35;
+    const h = (Math.sin(phase) * 0.5 + 0.5) * s.height * 0.6;
+
+    s.fill(255, 80);
+    s.rect(i * w, s.height - h, w * 0.9, h);
+  }
+
+  s.pop();
+}

--- a/src/sketch.js
+++ b/src/sketch.js
@@ -8,12 +8,14 @@ export function createSketch(s){
 	const PIPELINE = [
 		stage('BG', () => true, ({ s, sec, dt }) => {
 			s.background(0);
+		}),
+		stage('HUD', () => true, ({ s, sec, dt }) => {
 			s.fill(255);
 			s.textSize(24);
 			s.text('TEST', 40, 40);
       s.text(`sec: ${sec.toFixed(2)}`, 40, 80);
       s.text(`dt: ${dt.toFixed(3)}`, 40, 120);
-		}),
+		})
 	];
 	
 

--- a/src/sketch.js
+++ b/src/sketch.js
@@ -1,4 +1,5 @@
 import { stage } from './stage.js';
+import { drawTestEffect } from '../effects/TestEffect.js';
 
 export function createSketch(s){
 	let t0 = 0; //アプリが始まった瞬間の時間
@@ -6,9 +7,9 @@ export function createSketch(s){
 
 	//PIPELINE定義
 	const PIPELINE = [
-		stage('BG', () => true, ({ s, sec, dt }) => {
-			s.background(0);
-		}),
+		stage('BG', () => true, ({ s }) => { s.background(0); }),
+		stage('EFFECT_TEST', () => true, ({ s, sec, dt }) =>{ drawTestEffect(s, { sec, dt }); }),
+
 		stage('HUD', () => true, ({ s, sec, dt }) => {
 			s.fill(255);
 			s.textSize(24);


### PR DESCRIPTION
## 概要
`/effects` ディレクトリを導入し、テスト用の外部エフェクトモジュールを追加しました。
シンプルな `TestEffect`を実装し、`PIPELINE` から外部モジュールを呼び出せることを確認しています。

## やったこと

* `/effects`ディレクトリを追加
* 外部エフェクトモジュールを新規作成
* `sketch.js`からエフェクトを import
* `PIPELINE`にステージを追加し描画を確認
* HMRによる即時反映を確認